### PR TITLE
Unificar nombres

### DIFF
--- a/codex/content/es/posts/atrapados-en-el-tiempo.md
+++ b/codex/content/es/posts/atrapados-en-el-tiempo.md
@@ -2,7 +2,7 @@
 title: Atrapados en el Tiempos
 summary: "Les daré un pronóstico para el invierno: será frío, oscuro y durará... el resto de sus vidas. Phil Connors (Bill Murray)."
 authors:
-  - Jose Torrano Perez
+  - José Torrano Pérez
 date: 2012-02-20
 type: post
 categories:

--- a/codex/content/es/posts/b1-la-cripta-nefanda-de-uztum-el-maldito.md
+++ b/codex/content/es/posts/b1-la-cripta-nefanda-de-uztum-el-maldito.md
@@ -2,7 +2,7 @@
 title: B1 - La Cripta nefanda de Uztum el Maldito
 summary: Reúne a tu grupo de compañeros aventureros y atrévete a buscar la mítica cripta de Uztum, allende las Colinas Rojas, más allá de Reino Bosque y la Marca del Este, para descubrir sus secretos y maravillas de antaño. ¿Podrás sobrevevivir para ver otro día?
 authors:
-  - Pedro Gil "Steinkel"
+  - Pedro Gil
 
 date: 2014-10-08
 type: post

--- a/codex/content/es/posts/b2-la-isla-misteriosa.md
+++ b/codex/content/es/posts/b2-la-isla-misteriosa.md
@@ -2,7 +2,7 @@
 title: B2 - La isla misteriosa
 summary: Aventura para niveles 4-6 donde los aventureros deberán explorar una misteriosa isla llena de peligros
 authors:
-  - Pedro Gil "Steinkel"
+  - Pedro Gil
 date: 2015-06-26
 type: post
 categories:

--- a/codex/content/es/posts/c1-los-salones-anegados.md
+++ b/codex/content/es/posts/c1-los-salones-anegados.md
@@ -2,7 +2,7 @@
 title: C1 - Los Salones Anegados de Leviatán
 summary: En los más profundo del oscuro y tempestuoso océano, aguardan los míticos Salones Anegados de Leviatán, ahítos de monstruos terribles, reliquias de otrora y riquezas más allá de lo imaginado.
 authors:
-  - Luis F. “Tadevs”
+  - Luis Felipe García
 date: 2019-12-09
 type: post
 categories:

--- a/codex/content/es/posts/el-despertar-1-el-tesoro-de-los-faraones.md
+++ b/codex/content/es/posts/el-despertar-1-el-tesoro-de-los-faraones.md
@@ -2,7 +2,7 @@
 title: El Tesoro de los Faraones (El Despertar 1)
 summary: Esta primera parte se desarrolla en La Marca del Este, donde los aventureros serán contratados por el antiguo secretario de un Barón de Robleda, para que le ayuden a encontrar un Tesoro oculto en tierras Neferís.
 authors:
-  - José Torrano "Norak"
+  - José Torrano Pérez
 date: 2012-05-23
 type: post
 categories:

--- a/codex/content/es/posts/el-soberano-incapaz.md
+++ b/codex/content/es/posts/el-soberano-incapaz.md
@@ -2,7 +2,7 @@
 title: El Soberano Incapaz
 summary: "El Soberano Incapaz es tan solo la primera parte de una campaña titulada 'El Valle del dios astado' para la Marca del Este, inspirado en el cómic 'La Espada Salvaje de Conan'."
 authors:
-  - Luis Felipe Garcia / Tadevs
+  - Luis Felipe García
 date: 2012-11-04
 type: post
 categories:

--- a/codex/content/es/posts/sepultura-del-honor.md
+++ b/codex/content/es/posts/sepultura-del-honor.md
@@ -3,7 +3,7 @@ title: Sepultura del Honor
 summary:  Sepultura del Honor es la segunda parte de la campaña titulada “El Valle del Dios Astado” para La Marca del Este. En esta ocasión la mayor parte de la acción tendrá lugar en la Ciudadela de Frysev, fortaleza inventada por el autor que fue añadida al Canon del Códex de la Marca.
 
 authors:
-  - Luis Felipe Garcia / Tadevs
+  - Luis Felipe García
 date: 2012-11-04
 type: post
 categories:

--- a/codex/content/es/posts/serpientes-entre-las-ramas.md
+++ b/codex/content/es/posts/serpientes-entre-las-ramas.md
@@ -2,7 +2,7 @@
 title: Serpientes entre las ramas
 summary: Después de años de una tensa paz entre ambos reinos, una fuerza misteriosa está haciendo crecer rápidamente la selva de Ofir, ganándole día a día terreno al desierto, con un descontrolado crecimiento vegetal
 authors:
-  - José Torrano Pérez "Norkak"
+  - José Torrano Pérez
 date: 2013-07-22
 type: post
 categories:


### PR DESCRIPTION
Hola.

Algunos nombres en las fichas están escritos con criterios diferentes o incluso sin tildes y con. De esta manera, no aparecen unificados en la sección de [Autoría](https://codexdelamarca.com/authors/). Por ello, he unificado los nombres que he encontrado, con los siguientes criterios:

- Nombre y apellidos completos, donde he podido encontrarlos
- Nombres sin alias cuando ya existe el nombre completo
- Tildes donde corresponden

Algunos autores siguen apareciendo con un alias, pero sin el nombre.

Si me permitís el consejo, habría que unificar los criterios para cualquier nueva obra y en las existentes, para que luego sea fácil filtrar por autor o autores.

Un saludo.