### PR TITLE
Unificar nombre de la categoría Clásicos de la Marca

### DIFF
--- a/codex/content/es/posts/el-castillo-prohibido-de-la-reina-de-sangre.md
+++ b/codex/content/es/posts/el-castillo-prohibido-de-la-reina-de-sangre.md
@@ -7,7 +7,7 @@ authors:
 date: 2016-06-11
 type: post
 categories:
-- Clásicos
+- Clásicos de la Marca
 - Vermigor
 tags:
 - aventura

--- a/codex/content/es/posts/la-furia-de-rastilon.md
+++ b/codex/content/es/posts/la-furia-de-rastilon.md
@@ -6,7 +6,7 @@ authors:
 date: 2020-03-16
 type: post
 categories:
-- Clasicos
+- Clásicos de la Marca
 tags:
 - aventura
 - dungeon


### PR DESCRIPTION
Hola.

Existen 3 nombres diferentes para la categoría de Clásicos de la Marca. Este PR los unifica en uno solo.

Un saludo.