### PR TITLE
Enlace Descarga en módulo B11 - Las cuevas del clan atronador

### DIFF
--- a/codex/content/es/posts/b11-las-cuevas-del-clan-atronador.md
+++ b/codex/content/es/posts/b11-las-cuevas-del-clan-atronador.md
@@ -19,7 +19,7 @@ mincharacters: "4"
 maxcharacters: "5"
 eval: oficial
 cover: "b11-las-cuevas-del-clan-atronador.jpg"
-download:
+download: "lascuevasdelclanatronador.pdf"
 moreinfo: "https://tesorosdelamarca.com/producto/las-cuevas-del-clan-atronador/"
 license: "OGL"
 draft: false


### PR DESCRIPTION
Falta el enlace de descarga al pdf en el módulo de Las cuevas del clan atronador