### PR TITLE
Unificar formato de precios

### DIFF
--- a/codex/content/es/posts/B4-muerte-en-la-mansion-del-mago-malifax.md
+++ b/codex/content/es/posts/B4-muerte-en-la-mansion-del-mago-malifax.md
@@ -14,7 +14,7 @@ tags:
 - Exterior
 minlevels: "8"
 maxlevels: "9"
-prices: 6€
+prices: 6,00 €
 session: "1-2"
 mincharacters: "6"
 maxcharacters: "8"

--- a/codex/content/es/posts/B9-La última frontera.md
+++ b/codex/content/es/posts/B9-La última frontera.md
@@ -14,7 +14,7 @@ tags:
 - Exterior
 minlevels: "2"
 maxlevels: "4"
-prices: 7€
+prices: 7,00 €
 session: "1"
 mincharacters: "5"
 maxcharacters: "5"

--- a/codex/content/es/posts/BS1-bestiario.md
+++ b/codex/content/es/posts/BS1-bestiario.md
@@ -14,7 +14,7 @@ tags:
 - Reglamento
 minlevels: ""
 maxlevels: ""
-prices: 5€
+prices: 5,00 €
 session: ""
 mincharacters: ""
 maxcharacters: ""

--- a/codex/content/es/posts/PS1-manual-de-psionica.md
+++ b/codex/content/es/posts/PS1-manual-de-psionica.md
@@ -12,7 +12,7 @@ tags:
 - Reglamento
 minlevels: ""
 maxlevels: ""
-prices: 9€
+prices: 9,00 €
 session: ""
 mincharacters: ""
 maxcharacters: ""

--- a/codex/content/es/posts/SP1-tomo-de-magia.md
+++ b/codex/content/es/posts/SP1-tomo-de-magia.md
@@ -12,7 +12,7 @@ tags:
 - Reglamento
 minlevels: ""
 maxlevels: ""
-prices: 7€
+prices: 7,00 €
 session: ""
 mincharacters: ""
 maxcharacters: ""

--- a/codex/content/es/posts/b1-la-cripta-nefanda-de-uztum-el-maldito.md
+++ b/codex/content/es/posts/b1-la-cripta-nefanda-de-uztum-el-maldito.md
@@ -14,7 +14,7 @@ tags:
 - Dungeon
 minlevels: "1"
 maxlevels: "3"
-prices: 5€
+prices: 5,00 €
 session: "1"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b10-el-tumulo-perdido-de-azgoz-el-testarudo.md
+++ b/codex/content/es/posts/b10-el-tumulo-perdido-de-azgoz-el-testarudo.md
@@ -12,7 +12,7 @@ tags:
 - Dungeon
 minlevels: "1"
 maxlevels: "3"
-prices: 7,5€
+prices: 7,50 €
 session: "1-2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b13-sangre-en-la-nieve.md
+++ b/codex/content/es/posts/b13-sangre-en-la-nieve.md
@@ -14,7 +14,7 @@ tags:
 - Investigación
 minlevels: "2"
 maxlevels: "2"
-prices: 7.50€
+prices: 7,50 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b14-vileza-en-el bastion-de-los-bandidos.md
+++ b/codex/content/es/posts/b14-vileza-en-el bastion-de-los-bandidos.md
@@ -13,7 +13,7 @@ tags:
 - Dungeon
 minlevels: "2"
 maxlevels: "4"
-prices: 8€
+prices: 8,00 €
 session: "2"
 mincharacters: "3"
 maxcharacters: "6"

--- a/codex/content/es/posts/b17-el-bucaro de-alabastro.md
+++ b/codex/content/es/posts/b17-el-bucaro de-alabastro.md
@@ -15,7 +15,7 @@ tags:
 - templo
 minlevels: "3"
 maxlevels: "4"
-prices: 8€
+prices: 8,00 €
 session: "3"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b2-la-isla-misteriosa.md
+++ b/codex/content/es/posts/b2-la-isla-misteriosa.md
@@ -14,7 +14,7 @@ tags:
 - Isla
 minlevels: "4"
 maxlevels: "6"
-prices: 5€
+prices: 5,00 €
 session: "1"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b3-el-orbe-de-amonhotep.md
+++ b/codex/content/es/posts/b3-el-orbe-de-amonhotep.md
@@ -14,7 +14,7 @@ tags:
 - Dungeon
 minlevels: "5"
 maxlevels: "6"
-prices: 5€
+prices: 5,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/b5-incursion-a-la-tierra-del-dios-azul.md
+++ b/codex/content/es/posts/b5-incursion-a-la-tierra-del-dios-azul.md
@@ -14,7 +14,7 @@ tags:
 - Ciencia Fantasía
 minlevels: "4"
 maxlevels: "5"
-prices: 6€
+prices: 6,00 €
 session: "3"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/b6-tiempo-fuera-del-tiempo.md
+++ b/codex/content/es/posts/b6-tiempo-fuera-del-tiempo.md
@@ -13,7 +13,7 @@ tags:
 - Investigación
 minlevels: "2"
 maxlevels: "4"
-prices: 6€
+prices: 6,00 €
 session: "2"
 mincharacters: "3"
 maxcharacters: "5"

--- a/codex/content/es/posts/b7-presentes-sangrientos.md
+++ b/codex/content/es/posts/b7-presentes-sangrientos.md
@@ -14,7 +14,7 @@ tags:
 - Templo
 minlevels: "2"
 maxlevels: "4"
-prices: 6€
+prices: 6,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/b8-la-tumba-de-hielo.md
+++ b/codex/content/es/posts/b8-la-tumba-de-hielo.md
@@ -14,7 +14,7 @@ tags:
 - Oneshot
 minlevels: "1"
 maxlevels: "5"
-prices: 7€
+prices: 7,00 €
 session: "2"
 mincharacters: "1"
 maxcharacters: "5"

--- a/codex/content/es/posts/c1-los-salones-anegados.md
+++ b/codex/content/es/posts/c1-los-salones-anegados.md
@@ -14,7 +14,7 @@ tags:
 - Marítima
 minlevels: "5"
 maxlevels: "7"
-prices: 5€
+prices: 5,00 €
 session: "3"
 mincharacters: "3"
 maxcharacters: "6"

--- a/codex/content/es/posts/c3-el-jardin-negro.md
+++ b/codex/content/es/posts/c3-el-jardin-negro.md
@@ -15,7 +15,7 @@ tags:
 - Exploración
 minlevels: "6"
 maxlevels: "10"
-prices: 7€
+prices: 7,00 €
 session: "2-3"
 mincharacters: "1"
 maxcharacters: "5"

--- a/codex/content/es/posts/c4-la-cupula-de-huesos-de-ixambel.md
+++ b/codex/content/es/posts/c4-la-cupula-de-huesos-de-ixambel.md
@@ -14,7 +14,7 @@ tags:
 - Dungeon
 minlevels: "8"
 maxlevels: "11"
-prices: 7,5€
+prices: 7,50 €
 session: "2-3"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/caja_roja.md
+++ b/codex/content/es/posts/caja_roja.md
@@ -14,7 +14,7 @@ tags:
 - caja-roja
 minlevels: ""
 maxlevels: ""
-prices: 40€
+prices: 40,00 €
 session: ""
 mincharacters: ""
 maxcharacters: ""

--- a/codex/content/es/posts/cronicas-marca.md
+++ b/codex/content/es/posts/cronicas-marca.md
@@ -13,7 +13,7 @@ tags:
 - básico
 minlevels: "1"
 maxlevels: "100"
-prices: 30€
+prices: 30,00 €
 session: "indeterminado"
 mincharacters: "-"
 maxcharacters: "-"

--- a/codex/content/es/posts/ct1-la-lagrima-de-zurah.md
+++ b/codex/content/es/posts/ct1-la-lagrima-de-zurah.md
@@ -15,7 +15,7 @@ tags:
 - Exploración
 minlevels: "3"
 maxlevels: "4"
-prices: 6€
+prices: 6,00 €
 session: "3-4"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/el-legado-perdido.md
+++ b/codex/content/es/posts/el-legado-perdido.md
@@ -13,7 +13,7 @@ tags:
 - Exterior
 minlevels: "1"
 maxlevels: "2"
-prices: 8€
+prices: 8,00 €
 session: "2"
 mincharacters: "3"
 maxcharacters: "4"

--- a/codex/content/es/posts/el-misterio-de-baddon-roith.md
+++ b/codex/content/es/posts/el-misterio-de-baddon-roith.md
@@ -12,7 +12,7 @@ tags:
 - Torreón
 minlevels: "3"
 maxlevels: "5"
-prices: 1€
+prices: 1,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/el-tesoro-del-torreon-negro.md
+++ b/codex/content/es/posts/el-tesoro-del-torreon-negro.md
@@ -12,7 +12,7 @@ tags:
 - Oneshot
 minlevels: "1"
 maxlevels: "2"
-prices: "2€"
+prices: 2,00 €
 session: "1"
 mincharacters: "5"
 maxcharacters: "6"

--- a/codex/content/es/posts/el_enclave.md
+++ b/codex/content/es/posts/el_enclave.md
@@ -12,7 +12,7 @@ tags:
 - La Orden del Libro
 minlevels: "1"
 maxlevels: "3"
-prices: 17€
+prices: 17,00 €
 session: "4"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/gazetteer.md
+++ b/codex/content/es/posts/gazetteer.md
@@ -27,7 +27,7 @@ tags:
 - Gazetteer
 minlevels: "1"
 maxlevels: "100"
-prices: 40€
+prices: 40,00 €
 session: "indeterminado"
 mincharacters: "-"
 maxcharacters: "-"

--- a/codex/content/es/posts/ho1-lo-que-el-ojo-no-ve.md
+++ b/codex/content/es/posts/ho1-lo-que-el-ojo-no-ve.md
@@ -14,7 +14,7 @@ tags:
 - Urbano
 minlevels: "2"
 maxlevels: "3"
-prices: 12€
+prices: 12,00 €
 session: "4"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/justicia.md
+++ b/codex/content/es/posts/justicia.md
@@ -14,7 +14,7 @@ tags:
 - Exterior
 minlevels: "1"
 maxlevels: "2"
-prices: Gratis
+prices: gratis
 session: "1"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/la-caida-de-los-justos.md
+++ b/codex/content/es/posts/la-caida-de-los-justos.md
@@ -13,7 +13,7 @@ tags:
 - Oneshot
 minlevels: "1"
 maxlevels: "2"
-prices: "gratis"
+prices: gratis
 session: "1"
 mincharacters: "2"
 maxcharacters: "6"

--- a/codex/content/es/posts/la-fiesta-de-los-disfraces.md
+++ b/codex/content/es/posts/la-fiesta-de-los-disfraces.md
@@ -13,7 +13,7 @@ tags:
 - Investigación
 minlevels: "7"
 maxlevels: "10"
-prices: 10€
+prices: 10,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/la-furia-de-rastilon.md
+++ b/codex/content/es/posts/la-furia-de-rastilon.md
@@ -17,7 +17,7 @@ tags:
 - Ciencia Fantasía
 minlevels: "15"
 maxlevels: "17"
-prices: 7€
+prices: 7,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/la-tumba-olvidada.md
+++ b/codex/content/es/posts/la-tumba-olvidada.md
@@ -11,7 +11,7 @@ tags:
 - Dungeon
 minlevels: "5"
 maxlevels: "8"
-prices: 1 Euro
+prices: 1,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/mn2-la-balada-del-efimero-paladin.md
+++ b/codex/content/es/posts/mn2-la-balada-del-efimero-paladin.md
@@ -13,7 +13,7 @@ tags:
 - Exploración
 minlevels: "1"
 maxlevels: "2"
-prices: 8€
+prices: 8,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/no-profanaras-el-sueno-de-los-muertos.md
+++ b/codex/content/es/posts/no-profanaras-el-sueno-de-los-muertos.md
@@ -15,7 +15,7 @@ tags:
 - Investigación
 minlevels: "6"
 maxlevels: "8"
-prices: 9€
+prices: 9,00 €
 session: "no definido"
 mincharacters: "3"
 maxcharacters: "5"

--- a/codex/content/es/posts/planes_oscuros.md
+++ b/codex/content/es/posts/planes_oscuros.md
@@ -12,7 +12,7 @@ tags:
 - La Orden del Libro
 minlevels: "3"
 maxlevels: "4"
-prices: 17€
+prices: 17,00 €
 session: "5"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/redencion.md
+++ b/codex/content/es/posts/redencion.md
@@ -13,7 +13,7 @@ tags:
 - La Orden del Libro
 minlevels: "5"
 maxlevels: "6"
-prices: 17€
+prices: 17,00 €
 session: "4"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/s1-la-gesta-del-enano.md
+++ b/codex/content/es/posts/s1-la-gesta-del-enano.md
@@ -13,7 +13,7 @@ tags:
 - 1 Jugador
 minlevels: "4"
 maxlevels: "5"
-prices: 8€
+prices: 8,00 €
 session: "4"
 mincharacters: "1"
 maxcharacters: "1"

--- a/codex/content/es/posts/tn1-pacto-de-cenizas.md
+++ b/codex/content/es/posts/tn1-pacto-de-cenizas.md
@@ -15,7 +15,7 @@ tags:
 - El Trono de Niebla
 minlevels: "2"
 maxlevels: "4"
-prices: 7€
+prices: 7,00 €
 session: "2"
 mincharacters: "3"
 maxcharacters: "4"

--- a/codex/content/es/posts/tn2-el-feudo-en-llamas.md
+++ b/codex/content/es/posts/tn2-el-feudo-en-llamas.md
@@ -15,7 +15,7 @@ tags:
 - El Trono de Niebla
 minlevels: "3"
 maxlevels: "5"
-prices: 7€
+prices: 7,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/tn3-el-corazon-de-la-oscuridad.md
+++ b/codex/content/es/posts/tn3-el-corazon-de-la-oscuridad.md
@@ -14,7 +14,7 @@ tags:
 - El Trono de Niebla
 minlevels: "4"
 maxlevels: "5"
-prices: 40€
+prices: 40,00 €
 session: "15"
 mincharacters: "4"
 maxcharacters: "5"

--- a/codex/content/es/posts/todo-muere-menos-el-amor.md
+++ b/codex/content/es/posts/todo-muere-menos-el-amor.md
@@ -12,7 +12,7 @@ tags:
 - Investigación
 minlevels: "2"
 maxlevels: "4"
-prices: 1€
+prices: 1,00 €
 session: "2"
 mincharacters: "4"
 maxcharacters: "6"

--- a/codex/content/es/posts/v1-el-castillo-prohibido-de-la-reina-de-sangre.md
+++ b/codex/content/es/posts/v1-el-castillo-prohibido-de-la-reina-de-sangre.md
@@ -17,7 +17,7 @@ tags:
 - Exploración
 minlevels: "6"
 maxlevels: "10"
-prices: 8€
+prices: 8,00 €
 session: "?"
 mincharacters: "5"
 maxcharacters: "6"

--- a/codex/content/es/posts/x1-la-ciudad-perdida-de-garan.md
+++ b/codex/content/es/posts/x1-la-ciudad-perdida-de-garan.md
@@ -16,7 +16,7 @@ tags:
 - Exterior
 minlevels: "5"
 maxlevels: "8"
-prices: 7€
+prices: 7,00 €
 session: "3"
 mincharacters: "3"
 maxcharacters: "5"

--- a/codex/content/es/posts/x2-el-arca-de-los-mil-inviernos.md
+++ b/codex/content/es/posts/x2-el-arca-de-los-mil-inviernos.md
@@ -15,7 +15,7 @@ tags:
 - Isla
 minlevels: "6"
 maxlevels: "10"
-prices: 9€
+prices: 9,00 €
 session: "5-7"
 mincharacters: "4"
 maxcharacters: "7"


### PR DESCRIPTION
Esta PR trata de unificar los formatos de los precios siguiendo las recomendaciones de Ortografía de la lengua española, de la RAE, capítulo 4.4, sección:

> Los símbolos monetarios no alfabetizables se escriben en España preferentemente pospuestos y con blanco de separación, como es normal en el resto de los símbolos: 3 £, 50 $.

Fuente: https://www.rae.es/ortograf%c3%ada/ortograf%C3%ADa-y-otras-normas-de-escritura-1#4.4