### PR TITLE
Añadir Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ Entrar en carpeta `codex/` y ejecutar `hugo server -D`
 Para compilar estático, en la misma carpeta ejecutar `hugo` y comprobar contenido de la carpeta `public/`
 
 Se recomienda hugo versión >= 0.60
+
+## Usando Docker Compose
+
+Ejecutar:
+
+```shell
+docker compose up
+```
+
+Navegar a http://localhost:1313/.
+
+Pulsar `Ctrl+C` para parar.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,8 @@
+services:
+  server:
+    image: hugomods/hugo:exts-0.127.0
+    command: hugo server --bind=0.0.0.0 -D
+    volumes:
+      - ./codex/:/src
+    ports:
+      - 1313:1313


### PR DESCRIPTION
Esta PR añade un fichero de Docker Compose e instrucciones para poder hacer desarrollo local usando Docker, sin la necesidad de instalar Hugo. Además, se ciñe a la última versión compatible de Hugo, para evitar posibles incompatibilidades.